### PR TITLE
Support flexible model output shapes

### DIFF
--- a/lib/yolo_fast_nms.ex
+++ b/lib/yolo_fast_nms.ex
@@ -2,13 +2,16 @@ defmodule YoloFastNMS do
   @moduledoc """
   Runs Non-Maximum Suppression (NMS) on a given Nx tensor (or directly a binary) using a Rust NIF.
 
-  Currently, this implementation is specifically designed for a tensor with the shape `{84, 8400}` or `{1, 84, 8400}`,
-  which corresponds to the output of a YOLO model trained on the COCO dataset.
+  The implementation expects a tensor with shape `{rows, columns}` or `{1, rows, columns}` where:
+  - Each row represents a detection candidate.
+  - The columns consist of bounding box parameters followed by class probabilities.
+    - The first 4 columns are the bounding box parameters: `cx` (center x), `cy` (center y), `w` (width), and `h` (height).
+    - The remaining columns are the class probabilities for each class. The number of columns is the number of classes.
 
-  - The tensor's `8400` rows represent the detected objects.
-  - The first 4 columns contain the bounding box parameters: `cx` (center x),
-    `cy` (center y), `w` (width), and `h` (height).
-  - The remaining 80 columns represent the class probabilities.
+  The number of detection candidates (rows) and the number of columns (bounding box parameters + class probabilities) can vary depending on the model architecture.
+  For example, a YOLO model trained on the COCO dataset would have 80 class probabilities, resulting in a tensor with 84 columns (4 bbox parameters + 80 class probabilities). The number of rows is the number of detection candidates.
+
+  If your model outputs `{columns, rows}` (e.g., `{84, 8400}`), set `transpose: true` (default) in `run/2` options.
   """
   use Rustler, otp_app: :yolo_fast_nms, crate: "yolofastnms"
 
@@ -19,18 +22,23 @@ defmodule YoloFastNMS do
   ]
 
   @doc """
-  Runs Non-Maximum Suppression (NMS) on a tensor and returns a list of detected objects.
+  Runs Non-Maximum Suppression (NMS) on an Nx tensor and returns a list of detected objects.
 
   ## Parameters
-  - `tensor`: An Nx tensor with shape `{84, 8400}` or `{1, 84, 8400}` containing detection data
-  - `prob_threshold`: Minimum probability threshold (0..1) for detection confidence
-  - `iou_threshold`: IoU threshold (0..1) for overlap detection
 
-  Returns a list of lists `[cx, cy, w, h, prob, class_idx]` where:
-  - `cx`, `cy`: Center position coordinates of the detected object
-  - `w`, `h`: Width and height of the bounding box
-  - `prob`: Confidence score (between 0 and 1)
-  - `class_idx`: Index of the detected class
+    - `tensor`: An `Nx.Tensor` with shape `{rows, columns}` or `{1, rows, columns}`. Each row is a detection candidate, with the first 4 columns as bounding box parameters (`cx`, `cy`, `w`, `h`) and the remaining columns as class probabilities.
+    - `options`: Keyword list of options:
+      - `:prob_threshold` (float, default: 0.25) — Minimum probability threshold for detection confidence.
+      - `:iou_threshold` (float, default: 0.5) — IoU threshold for overlap suppression.
+      - `:transpose` (boolean, default: true) — Whether to transpose the input tensor (set to true if your tensor shape is `{columns, rows}`).
+
+  ## Returns
+
+    - A list of lists `[cx, cy, w, h, prob, class_idx]` for each detected object, where:
+      - `cx`, `cy`: Center coordinates of the bounding box.
+      - `w`, `h`: Width and height of the bounding box.
+      - `prob`: Confidence score (0..1).
+      - `class_idx`: Index of the detected class.
   """
   @spec run(Nx.Tensor.t(), options :: keyword()) :: [[float()]]
   def run(%Nx.Tensor{} = tensor, options) do
@@ -55,7 +63,9 @@ defmodule YoloFastNMS do
   Runs Non-Maximum Suppression (NMS) directly on a binary containing detection data.
 
   ## Parameters
-  - `tensor_binary`: A binary containing detection data in shape `{84, 8400}`
+  - `tensor_binary`: A binary containing detection data in shape `{rows, columns}` where:
+    - The first 4 columns contain bounding box parameters (cx, cy, w, h)
+    - The remaining columns contain class probabilities
   - `prob_threshold` - Minimum probability threshold (0..1) for detection confidence
   - `iou_threshold` - IoU threshold (0..1) for overlap detection
   - `rows` - Number of rows in the tensor

--- a/lib/yolo_fast_nms.ex
+++ b/lib/yolo_fast_nms.ex
@@ -12,11 +12,17 @@ defmodule YoloFastNMS do
   """
   use Rustler, otp_app: :yolo_fast_nms, crate: "yolofastnms"
 
+  @default_options [
+    prob_threshold: 0.25,
+    iou_threshold: 0.5,
+    transpose: true
+  ]
+
   @doc """
   Runs Non-Maximum Suppression (NMS) on a tensor and returns a list of detected objects.
 
   ## Parameters
-  - `tensor`: An Nx tensor with shape `{84, 8400}` containing detection data
+  - `tensor`: An Nx tensor with shape `{84, 8400}` or `{1, 84, 8400}` containing detection data
   - `prob_threshold`: Minimum probability threshold (0..1) for detection confidence
   - `iou_threshold`: IoU threshold (0..1) for overlap detection
 
@@ -26,11 +32,23 @@ defmodule YoloFastNMS do
   - `prob`: Confidence score (between 0 and 1)
   - `class_idx`: Index of the detected class
   """
-  @spec run(Nx.Tensor.t(), prob_threshold :: float(), iou_threshold :: float()) :: [[float()]]
-  def run(%Nx.Tensor{} = tensor, prob_threshold, iou_threshold) do
+  @spec run(Nx.Tensor.t(), options :: keyword()) :: [[float()]]
+  def run(%Nx.Tensor{} = tensor, options) do
+    options = Keyword.merge(@default_options, options)
+    iou_threshold = Keyword.get(options, :iou_threshold, @default_options[:iou_threshold])
+    prob_threshold = Keyword.get(options, :prob_threshold, @default_options[:prob_threshold])
+    transpose = Keyword.get(options, :transpose, @default_options[:transpose])
+
+    {rows, columns} =
+      case Nx.shape(tensor) do
+        {1, rows, columns} -> {rows, columns}
+        {rows, columns} -> {rows, columns}
+        _ -> raise "Invalid tensor shape"
+      end
+
     tensor
     |> Nx.to_binary()
-    |> run_with_binary(prob_threshold, iou_threshold)
+    |> run_with_binary(prob_threshold, iou_threshold, rows, columns, transpose)
   end
 
   @doc """
@@ -38,8 +56,11 @@ defmodule YoloFastNMS do
 
   ## Parameters
   - `tensor_binary`: A binary containing detection data in shape `{84, 8400}`
-  - `prob_threshold`: Minimum probability threshold (0..1) for detection confidence
-  - `iou_threshold`: IoU threshold (0..1) for overlap detection
+  - `prob_threshold` - Minimum probability threshold (0..1) for detection confidence
+  - `iou_threshold` - IoU threshold (0..1) for overlap detection
+  - `rows` - Number of rows in the tensor
+  - `columns` - Number of columns in the tensor
+  - `transpose` - Whether to transpose the input tensor
 
   Returns a list of lists `[cx, cy, w, h, prob, class_idx]` where:
   - `cx`, `cy`: Center position coordinates of the detected object
@@ -47,8 +68,15 @@ defmodule YoloFastNMS do
   - `prob`: Confidence score (between 0 and 1)
   - `class_idx`: Index of the detected class
   """
-  @spec run_with_binary(tensor_binary :: binary(), prob_threshold :: float(), iou_threshold :: float()) :: [[float()]]
-  def run_with_binary(tensor_binary, _prob_threshold, _iou_threshold)
+  @spec run_with_binary(
+          tensor_binary :: binary(),
+          prob_threshold :: float(),
+          iou_threshold :: float(),
+          rows :: integer(),
+          columns :: integer(),
+          transpose :: boolean()
+        ) :: [[float()]]
+  def run_with_binary(tensor_binary, _prob_threshold, _iou_threshold, _rows, _columns, _transpose)
       when is_binary(tensor_binary),
       do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/test/yolo_fast_nms_test.exs
+++ b/test/yolo_fast_nms_test.exs
@@ -1,7 +1,7 @@
 defmodule YoloFastNMSTest do
   use ExUnit.Case
 
-  test "filtering all bboxes below 0.4 confidence" do
+  test "filtering all bboxes below 0.4 confidence with default options 84x8400" do
     model_output =
       [
         # non overlapping people, with confidence equal or higher than 0.4
@@ -32,8 +32,46 @@ defmodule YoloFastNMSTest do
              [2, 1, 20, 10, 0.7, 2]
            ]) ==
              model_output
-             |> YoloFastNMS.run(0.4, 0.5)
+             |> YoloFastNMS.run(prob_threshold: 0.4, iou_threshold: 0.5, classes_count: 80)
              |> round_results()
+             |> MapSet.new()
+  end
+
+  test "filtering 10x4 model output (4 detections and 6 classes)" do
+    model_output =
+      [
+        detection_row([0, 0, 10, 20], 0.4, 0, 6),
+        detection_row([10, 40, 10, 20], 0.5, 1, 6),
+        detection_row([20, 60, 10, 20], 0.6, 2, 6),
+        detection_row([30, 80, 10, 20], 0.7, 3, 6)
+      ]
+      |> Nx.tensor(type: {:f, 32})
+      |> Nx.transpose(axes: [1, 0])
+
+    # model_output is 10x4 (4 detections and 10 columns: 4 bbox elements + 6 classes)
+    assert MapSet.new([{0.6, 2.0}, {0.7, 3.0}]) ==
+             model_output
+             |> YoloFastNMS.run(prob_threshold: 0.55, iou_threshold: 0.5, transpose: true)
+             |> Enum.map(fn [_, _, _, _, prob, idx] -> {Float.round(prob, 2), idx} end)
+             |> MapSet.new()
+  end
+
+  test "not transposing during filtering" do
+    model_output =
+      [
+        detection_row([0, 0, 10, 20], 0.4, 0, 6),
+        detection_row([10, 40, 10, 20], 0.5, 1, 6),
+        detection_row([20, 60, 10, 20], 0.6, 2, 6),
+        detection_row([30, 80, 10, 20], 0.7, 3, 6)
+      ]
+      |> Nx.tensor(type: {:f, 32})
+
+    # model_output is 10x4 (4 detections and 10 columns: 4 bbox elements + 6 classes)
+
+    assert MapSet.new([{0.6, 2.0}, {0.7, 3.0}]) ==
+             model_output
+             |> YoloFastNMS.run(prob_threshold: 0.55, iou_threshold: 0.5, transpose: false)
+             |> Enum.map(fn [_, _, _, _, prob, idx] -> {Float.round(prob, 2), idx} end)
              |> MapSet.new()
   end
 
@@ -50,10 +88,15 @@ defmodule YoloFastNMSTest do
     end)
   end
 
-  @spec detection_row(bbox :: [integer()], prob :: float(), class_idx :: integer()) :: [Float.t()]
-  defp detection_row(bbox, prob, class_idx) do
-    # 4 elements for bounding box, 80 classes,
-    class_cols = Enum.map(0..79, fn _ -> 0 end)
+  @spec detection_row(
+          bbox :: [integer()],
+          prob :: float(),
+          class_idx :: integer(),
+          classes_count :: integer()
+        ) :: [Float.t()]
+  defp detection_row(bbox, prob, class_idx, classes_count \\ 80) do
+    # 4 elements for bounding box, `classes_count` classes,
+    class_cols = Enum.map(0..(classes_count - 1), fn _ -> 0 end)
 
     bbox ++ List.replace_at(class_cols, class_idx, prob)
   end


### PR DESCRIPTION
This PR refactors `YoloFastNMS` to support flexible input tensor shapes, removing the previous hardcoded constraint for `{84, 8400}` tensors.

The `run/2` function now accepts a keyword list of options (`:prob_threshold`, `:iou_threshold`, `:transpose`) and can handle various tensor shapes like `{rows, columns}`. The underlying Rust NIF has been updated to dynamically manage dimensions.